### PR TITLE
Dev/1 nonnumeric

### DIFF
--- a/parameter_assertions/include/parameter_assertions/assertions.h
+++ b/parameter_assertions/include/parameter_assertions/assertions.h
@@ -22,7 +22,8 @@ enum class NumberAssertionType
  * @tparam T Type for the argument of the assertion predicate
  */
 template <typename T>
-struct Assertion {
+struct Assertion
+{
   std::function<bool(const T&)> predicate;
   std::string expectation;
 
@@ -33,7 +34,9 @@ struct Assertion {
    * @param expectation a string explaining the expected case, to be shown when the predicate evaluates to false
    */
   Assertion(std::function<bool(const T&)> predicate, std::string expectation)
-      : predicate(predicate), expectation(std::move(expectation)) {}
+    : predicate(predicate), expectation(std::move(expectation))
+  {
+  }
 };
 
 /**
@@ -80,7 +83,6 @@ Assertion<T> less_eq(const T& rhs);
  */
 template <typename T>
 Assertion<T> size(size_t n);
-
 
 /**
  * Calls nh.param with the passed in values. Logs with ROS_WARN_STREAM if the default value is used. Returns the

--- a/parameter_assertions/include/parameter_assertions/assertions.h
+++ b/parameter_assertions/include/parameter_assertions/assertions.h
@@ -16,8 +16,71 @@ enum class NumberAssertionType
   ABS_LESS_THAN_EQ_ONE,
 };
 
+/**
+ * Assertion template class. Given an instance of T, specify some arbitrary operation to check if that instance
+ * is valid.
+ * @tparam T Type for the argument of the assertion predicate
+ */
 template <typename T>
-using AssertionFP = typename std::add_pointer<bool(const T&)>::type;
+struct Assertion {
+  std::function<bool(const T&)> predicate;
+  std::string expectation;
+
+  /**
+   * Assertion constructor.
+   * Intended usage: assertions::Assertion<int> is_even([](int x) { return x % 2 == 0; }, "param is even");
+   * @param predicate a function mapping from T (or const T&) to bool, whether or not the parameter value is acceptable
+   * @param expectation a string explaining the expected case, to be shown when the predicate evaluates to false
+   */
+  Assertion(std::function<bool(const T&)> predicate, std::string expectation)
+      : predicate(predicate), expectation(std::move(expectation)) {}
+};
+
+/**
+ * Generate an Assertion<T> that the parameter is > rhs
+ * @tparam T
+ * @param rhs
+ * @return
+ */
+template <typename T>
+Assertion<T> greater(const T& rhs);
+
+/**
+ * Generate an Assertion<T> that the parameter is >= rhs
+ * @tparam T
+ * @param rhs
+ * @return
+ */
+template <typename T>
+Assertion<T> greater_eq(const T& rhs);
+
+/**
+ * Generate an Assertion<T> that the parameter is < rhs
+ * @tparam T
+ * @param rhs
+ * @return
+ */
+template <typename T>
+Assertion<T> less(const T& rhs);
+
+/**
+ * Generate an Assertion<T> that the parameter is <= rhs
+ * @tparam T
+ * @param rhs
+ * @return
+ */
+template <typename T>
+Assertion<T> less_eq(const T& rhs);
+
+/**
+ * Generate an Assertion<T> that the parameter contains exactly rhs elements, where T supports .size()
+ * @tparam T
+ * @param rhs
+ * @return
+ */
+template <typename T>
+Assertion<T> n_elements(size_t n);
+
 
 /**
  * Calls nh.param with the passed in values. Logs with ROS_WARN_STREAM if the default value is used. Returns the
@@ -35,7 +98,7 @@ bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_va
 
 /**
  * Calls nh.param with the passed in values. Logs with ROS_WARN_STREAM if the default value is used. Returns the
- * result of nh.param
+ * result of nh.param()
  *
  * @tparam T
  * @param nh ros::NodeHandle to use
@@ -47,8 +110,10 @@ template <typename T>
 [[nodiscard]] T param(const ros::NodeHandle& nh, const std::string& param_name, const T& default_val);
 
 /**
- * Calls nh.param with the passed in values. Logs with ROS_WARN_STREAM if the default value is used. Returns the
- * result of nh.param
+ * Calls nh.param() with the passed in values. Logs with ROS_WARN_STREAM if the default value is used. Returns
+ * true if the value is available on the parameter server and passes all assertions. If any assertion fails, the
+ * default is tried, and if any fail again, ros::shutdown() is called. This version uses the enum NumberAssertionType
+ * and is only applicable to doubles, floats, and ints
  *
  * @tparam T
  * @param nh ros::NodeHandle to use
@@ -63,8 +128,18 @@ bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_va
            const std::vector<NumberAssertionType>& assertions);
 
 /**
- * Calls nh.param with the passed in values. Logs with ROS_WARN_STREAM if the default value is used. Returns the
- * result of nh.param
+ * See other function with the same signature. This version exists to warn that the user is applying
+ * NumberAssertionType to something other than double, float, or int
+ */
+template <typename T, typename type_traits::disable_if<type_traits::is_number<T>::value, T>::type* = nullptr>
+bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_var, const T& default_val,
+           const std::vector<NumberAssertionType>&);
+
+/**
+ * Calls nh.param() with the passed in values. Logs with ROS_WARN_STREAM if the default value is used. Returns
+ * true if the value is available on the parameter server and passes all assertions. If any assertion fails, the
+ * default is tried, and if any fail again, ros::shutdown() is called. This version uses Assertion<T> and is
+ * applicable to all types returned by nh.param()
  *
  * @tparam T
  * @param nh ros::NodeHandle to use
@@ -74,13 +149,15 @@ bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_va
  * @param assertions List of assertions to apply to the parameter
  * @return
  */
-template <typename T, typename type_traits::disable_if<type_traits::is_number<T>::value, T>::type* = nullptr>
+template <typename T>
 bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_var, const T& default_val,
-           const std::vector<NumberAssertionType>& assertions);
+           const std::vector<Assertion<T>>& assertions);
 
 /**
- * Calls nh.param with the passed in values. Logs with ROS_WARN_STREAM if the default value is used. Returns the
- * result of nh.param
+ * Calls nh.param() with the passed in values. Logs with ROS_WARN_STREAM if the default value is used. Returns
+ * the value from the parameter server if it is available and passes all assertions. If any assertion fails, the
+ * default is attempted and possibly returned, and if any assertions fail on the default, ros::shutdown() is called.
+ * This version uses the enum NumberAssertionType and is only applicable to doubles, floats, and ints
  *
  * @tparam T
  * @param nh ros::NodeHandle to use
@@ -94,24 +171,74 @@ template <typename T>
                       const std::vector<NumberAssertionType>& assertions);
 
 /**
- * Calls nh.getParam with the passed in values. If getParam returns false, calls ros::shutdown if exit_on_failure_
- * is false, otherwise does std::exit(-1).
+ * Calls nh.param() with the passed in values. Logs with ROS_WARN_STREAM if the default value is used. Returns
+ * the value from the parameter server if it is available and passes all assertions. If any assertion fails, the
+ * default is attempted and possibly returned, and if any assertions fail on the default, ros::shutdown() is called.
+ * This version uses Assertion<T> and is applicable to all types returned by nh.param()
+ *
+ * @tparam T
+ * @param nh ros::NodeHandle to use
+ * @param param_name
+ * @param default_val
+ * @param assertions List of assertions to apply to the parameter
+ * @return
+ */
+template <typename T>
+[[nodiscard]] T param(const ros::NodeHandle& nh, const std::string& param_name, const T& default_val,
+                      const std::vector<Assertion<T>>& assertions);
+
+/**
+ * Calls nh.getParam() with the passed in values. Logs with ROS_ERROR_STREAM and calls ros::shutdown() if the default
+ * value is used. Returns the result of nh.getParam(), which is true unless ros::shutdown() is called
  *
  * @tparam T
  * @param nh ros::NodeHandle to use
  * @param param_name
  * @param param_val
+ * @return
  */
 template <typename T>
 bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param_var);
 
+/**
+ * Calls nh.getParam() with the passed in values. Logs with ROS_ERROR_STREAM and calls ros::shutdown() if the default
+ * value is used. Returns the result of nh.getParam(), which is true unless ros::shutdown() is called. If any assertion
+ * fails, ros::shutdown() is called. This version uses the enum NumberAssertionType and is only applicable to
+ * doubles, floats, and ints
+ *
+ * @tparam T
+ * @param nh ros::NodeHandle to use
+ * @param param_name
+ * @param param_val
+ * @return
+ */
 template <typename T, typename std::enable_if<type_traits::is_number<T>::value, T>::type* = nullptr>
 bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param_var,
               const std::vector<NumberAssertionType>& assertions);
 
+/**
+ * See other function with the same signature. This version exists to warn that the user is applying
+ * NumberAssertionType to something other than double, float, or int
+ */
 template <typename T, typename type_traits::disable_if<type_traits::is_number<T>::value, T>::type* = nullptr>
 bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param_var,
               const std::vector<NumberAssertionType>& assertions);
+
+/**
+ * Calls nh.getParam() with the passed in values. Logs with ROS_ERROR_STREAM and calls ros::shutdown() if the default
+ * value is used. Returns the result of nh.getParam(), which is true unless ros::shutdown() is called. If any assertion
+ * fails, ros::shutdown() is called. This version uses Assertion<T> and is applicable to all types returned by
+ * nh.getParam()
+ *
+ * @tparam T
+ * @param nh ros::NodeHandle to use
+ * @param param_name
+ * @param param_val
+ * @return
+ */
+template <typename T>
+bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param_var,
+              const std::vector<Assertion<T>>& assertions);
 
 }  // namespace assertions
 

--- a/parameter_assertions/include/parameter_assertions/assertions.h
+++ b/parameter_assertions/include/parameter_assertions/assertions.h
@@ -79,7 +79,7 @@ Assertion<T> less_eq(const T& rhs);
  * @return
  */
 template <typename T>
-Assertion<T> n_elements(size_t n);
+Assertion<T> size(size_t n);
 
 
 /**

--- a/parameter_assertions/src/assertions.cpp
+++ b/parameter_assertions/src/assertions.cpp
@@ -75,8 +75,8 @@ Assertion<T> getNumericAssertion(NumberAssertionType assertion_type, const T& va
     case NumberAssertionType::LESS_THAN_EQ_ONE:
       return { [](const T& param) { return param <= 1; }, std::to_string(variable) + " must be <= 1." };
     case NumberAssertionType::ABS_LESS_THAN_EQ_ONE:
-      return { [](const T& param) { return std::abs(param) <= 1; },
-               std::to_string(variable) + " must have an absolute value <= 1." };
+      return { [](const T& param) { return std::abs(param) <= 1; }, std::to_string(variable) + " must have an absolute "
+                                                                                               "value <= 1." };
     default:
       ROS_ERROR_STREAM("default case reached in getNumericAssertion even though match was exhaustive");
       return { [](const T& /*param*/) { return false; }, "valid NumberAssertionType" };

--- a/parameter_assertions/src/assertions.cpp
+++ b/parameter_assertions/src/assertions.cpp
@@ -52,7 +52,7 @@ template <typename T>
 constexpr bool enable_fallback = !type_traits::is_vector<T>::value && !std::is_arithmetic<T>::value;
 
 template <typename T, typename std::enable_if<enable_fallback<T>, T>::type* = nullptr>
-void warnDefaultWithMessage(const std::string& node_namespace, const std::string& variable_name, T& /* variable */,
+void warnDefaultWithMessage(const std::string& node_namespace, const std::string& variable_name, const T& /* unused */,
                             const std::string& message)
 {
   std::string variable_str = "<non-printable value>";

--- a/parameter_assertions/src/assertions.cpp
+++ b/parameter_assertions/src/assertions.cpp
@@ -25,92 +25,75 @@ std::string vectorToString(const std::vector<T>& vector)
   return ss.str();
 }
 
-template <typename T, typename type_traits::disable_if<type_traits::is_vector<T>::value, T>::type* = nullptr>
-void warnDefaultWithMessage(const std::string& node_namespace, const std::string& variable_name, T& variable,
-                            const std::string& message)
+void warnDefaultWithMessage(const std::string& node_namespace, const std::string& variable_name,
+                            const std::string& variable, const std::string& message)
 {
   ROS_WARN_STREAM("[" << node_namespace << "] " << variable_name << message << ". Continuing with default values "
                       << variable);
 }
 
-template <typename V, typename std::enable_if<type_traits::is_vector<V>::value, V>::type* = nullptr>
-void warnDefaultWithMessage(const std::string& node_namespace, const std::string& variable_name, V& variable,
+template <typename T, typename std::enable_if<std::is_arithmetic<T>::value, T>::type* = nullptr>
+void warnDefaultWithMessage(const std::string& node_namespace, const std::string& variable_name, T& variable,
                             const std::string& message)
 {
-  std::string vector_str = vectorToString(variable);
-  warnDefaultWithMessage(node_namespace, variable_name, vector_str, message);
+  std::string variable_str = std::to_string(variable);
+  warnDefaultWithMessage(node_namespace, variable_name, variable_str, message);
+}
+
+template <typename T, typename std::enable_if<type_traits::is_vector<T>::value, T>::type* = nullptr>
+void warnDefaultWithMessage(const std::string& node_namespace, const std::string& variable_name, T& variable,
+                            const std::string& message)
+{
+  std::string variable_str = vectorToString(variable);
+  warnDefaultWithMessage(node_namespace, variable_name, variable_str, message);
 }
 
 template <typename T>
-AssertionFP<T> getAssertionFunction(NumberAssertionType assertion_type)
+constexpr bool enable_fallback = !type_traits::is_vector<T>::value && !std::is_arithmetic<T>::value;
+
+template <typename T, typename std::enable_if_t<enable_fallback<T>, T>* = nullptr>
+void warnDefaultWithMessage(const std::string& node_namespace, const std::string& variable_name, T& /* variable */,
+                            const std::string& message)
+{
+  std::string variable_str = "<non-printable value>";
+  warnDefaultWithMessage(node_namespace, variable_name, variable_str, message);
+}
+
+template <typename T, typename std::enable_if<type_traits::is_number<T>::value, T>::type* = nullptr>
+Assertion<T> getNumericAssertion(NumberAssertionType assertion_type, const T& variable)
 {
   switch (assertion_type)
   {
     case NumberAssertionType::POSITIVE:
-      return [](const T& param) { return param > 0; };
+      return {[](const T& param) { return param > 0; }, std::to_string(variable) + " must be > 0."};
     case NumberAssertionType::NON_NEGATIVE:
-      return [](const T& param) { return param >= 0; };
+      return {[](const T& param) { return param >= 0; }, std::to_string(variable) + " must be >= 0."};
     case NumberAssertionType::NEGATIVE:
-      return [](const T& param) { return param < 0; };
+      return {[](const T& param) { return param < 0; }, std::to_string(variable) + " must be < 0."};
     case NumberAssertionType::NON_POSITIVE:
-      return [](const T& param) { return param <= 0; };
+      return {[](const T& param) { return param <= 0; }, std::to_string(variable) + " must be <= 0."};
     case NumberAssertionType::LESS_THAN_EQ_ONE:
-      return [](const T& param) { return param <= 1; };
+      return {[](const T& param) { return param <= 1; }, std::to_string(variable) + " must be <= 1."};
     case NumberAssertionType::ABS_LESS_THAN_EQ_ONE:
-      return [](const T& param) { return std::abs(param) <= 1; };
+      return {[](const T& param) { return std::abs(param) <= 1; },
+              std::to_string(variable) + " must have an absolute value <= 1."};
     default:
-      ROS_ERROR_STREAM("default case reached in getAssertionFunction even though match was exhaustive");
-      return [](const T& /*param*/) { return false; };
+      ROS_ERROR_STREAM("default case reached in getNumericAssertion even though match was exhaustive");
+      return {[](const T& /*param*/) { return false; }, "valid NumberAssertionType"};
   }
 }
 
 template <typename T>
-std::string getAssertionErrorMessage(NumberAssertionType assertion_type, const T& variable)
+std::optional<std::string> getErrorMessage(const T& variable, const std::vector<Assertion<T>>& assertions)
 {
-  switch (assertion_type)
+  for (const Assertion<T>& assertion: assertions)
   {
-    case NumberAssertionType::POSITIVE:
-      return std::to_string(variable) + " must be > 0.";
-    case NumberAssertionType::NON_NEGATIVE:
-      return std::to_string(variable) + " must be >= 0.";
-    case NumberAssertionType::NEGATIVE:
-      return std::to_string(variable) + " must be < 0.";
-    case NumberAssertionType::NON_POSITIVE:
-      return std::to_string(variable) + " must be <= 0.";
-    case NumberAssertionType::LESS_THAN_EQ_ONE:
-      return std::to_string(variable) + " must be <= 1.";
-    case NumberAssertionType::ABS_LESS_THAN_EQ_ONE:
-      return std::to_string(variable) + " must have an absolute value <= 1.";
-    default:
-      ROS_ERROR_STREAM("default case reached in getAssertionFunction even though match was exhaustive");
-      return "";
-  }
-}
-
-template <typename T, typename type_traits::disable_if<type_traits::is_vector<T>::value, T>::type* = nullptr>
-std::optional<std::string> getErrorMessage(const T& variable, const std::vector<NumberAssertionType>& assertions)
-{
-  for (const auto& assertion : assertions)
-  {
-    if (!getAssertionFunction<T>(assertion)(variable))
+    if (!assertion.predicate(variable))
     {
-      return getAssertionErrorMessage(assertion, variable);
+      return assertion.expectation;
     }
   }
   return std::nullopt;
-}
-
-template <typename V, typename std::enable_if<type_traits::is_vector<V>::value, V>::type* = nullptr>
-bool passesAssertion(V& variable, const std::vector<NumberAssertionType>& assertions)
-{
-  for (const auto& element : variable)
-  {
-    if (!passesAssertion(element, assertions))
-    {
-      return false;
-    }
-  }
-  return true;
 }
 
 void fail()
@@ -119,6 +102,27 @@ void fail()
 }
 
 }  // namespace
+
+template <typename T> Assertion<T> greater(const T& rhs) {
+  return Assertion<T>([&rhs](const T& lhs) { return lhs > rhs; }, "x > " + std::to_string(rhs));
+}
+
+template <typename T> Assertion<T> greater_eq(const T& rhs) {
+  return Assertion<T>([&rhs](const T& lhs) { return lhs >= rhs; }, "x >= " + std::to_string(rhs));
+}
+
+template <typename T> Assertion<T> less(const T& rhs) {
+  return Assertion<T>([&rhs](const T& lhs) { return lhs < rhs; }, "x < " + std::to_string(rhs));
+}
+
+template <typename T> Assertion<T> less_eq(const T& rhs) {
+  return Assertion<T>([&rhs](const T& lhs) { return lhs <= rhs; }, "x <= " + std::to_string(rhs));
+}
+
+template <typename T> Assertion<T> n_elements(size_t n) {
+  return Assertion<T>([n](const T& c) { return c.size() == n; }, "container.size() = " + std::to_string(n));
+}
+
 
 template <typename T>
 bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_var, const T& default_val)
@@ -139,9 +143,9 @@ T param(const ros::NodeHandle& nh, const std::string& param_name, const T& defau
   return param_var;
 }
 
-template <typename T, typename std::enable_if<type_traits::is_number<T>::value, T>::type*>
+template <typename T>
 bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_var, const T& default_val,
-           const std::vector<NumberAssertionType>& assertions)
+           const std::vector<Assertion<T>>& assertions)
 {
   if (nh.getParam(param_name, param_var))
   {
@@ -168,9 +172,20 @@ bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_va
   return false;
 }
 
+template <typename T, typename std::enable_if<type_traits::is_number<T>::value, T>::type*>
+bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_var, const T& default_val,
+           const std::vector<NumberAssertionType>& numeric_assertions)
+{
+  std::vector<Assertion<T>> assertions;
+  for (auto numeric_assertion : numeric_assertions) {
+    assertions.push_back(getNumericAssertion(numeric_assertion, param_var));
+  }
+  return param(nh, param_name, param_var, default_val, assertions);
+}
+
 template <typename T, typename type_traits::disable_if<type_traits::is_number<T>::value, T>::type*>
 bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_var, const T& default_val,
-           const std::vector<NumberAssertionType>& assertions)
+           const std::vector<NumberAssertionType>& /* assertions */)
 {
   ROS_WARN_STREAM("[" << nh.getNamespace() << "] An assertion was set for " << param_name
                       << " but it is not a number. Continuing without assertions.");
@@ -181,6 +196,15 @@ bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_va
 template <typename T>
 T param(const ros::NodeHandle& nh, const std::string& param_name, const T& default_val,
         const std::vector<NumberAssertionType>& assertions)
+{
+  T param_var;
+  param(nh, param_name, param_var, default_val, assertions);
+  return param_var;
+}
+
+template <typename T>
+T param(const ros::NodeHandle& nh, const std::string& param_name, const T& default_val,
+        const std::vector<Assertion<T>>& assertions)
 {
   T param_var;
   param(nh, param_name, param_var, default_val, assertions);
@@ -200,9 +224,9 @@ bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param
   return true;
 }
 
-template <typename T, typename std::enable_if<type_traits::is_number<T>::value, T>::type*>
+template <typename T>
 bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param_var,
-              const std::vector<NumberAssertionType>& assertions)
+              const std::vector<Assertion<T>>& assertions)
 {
   if (getParam(nh, param_name, param_var))
   {
@@ -217,127 +241,71 @@ bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param
   return true;
 }
 
+template <typename T, typename std::enable_if<type_traits::is_number<T>::value, T>::type*>
+bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param_var,
+              const std::vector<NumberAssertionType>& numeric_assertions)
+{
+  std::vector<Assertion<T>> assertions;
+  for (auto numeric_assertion : numeric_assertions) {
+    assertions.push_back(getNumericAssertion(numeric_assertion, param_var));
+  }
+  return getParam(nh, param_name, param_var, assertions);
+}
+
 template <typename T, typename type_traits::disable_if<type_traits::is_number<T>::value, T>::type*>
 bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param_var,
               const std::vector<NumberAssertionType>& /*assertions*/)
 {
-  ROS_WARN_STREAM("[" << nh.getNamespace() << "] An assertion was set for " << param_name
+  ROS_WARN_STREAM("[" << nh.getNamespace() << "] A numeric assertion was set for " << param_name
                       << " but it is not a number. Continuing without assertions.");
 
   return getParam(nh, param_name, param_var);
 }
 
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, std::string& param_var);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, double& param_var);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, float& param_var);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, int& param_var);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, bool& param_var);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, std::vector<std::string>& param_var);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, std::vector<double>& param_var);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, std::vector<float>& param_var);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, std::vector<int>& param_var);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, std::vector<bool>& param_var);
 
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, std::string& param_var,
-                       const std::vector<NumberAssertionType>& assertions);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, double& param_var,
-                       const std::vector<NumberAssertionType>& assertions);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, float& param_var,
-                       const std::vector<NumberAssertionType>& assertions);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, int& param_var,
-                       const std::vector<NumberAssertionType>& assertions);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, bool& param_var,
-                       const std::vector<NumberAssertionType>& assertions);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, std::vector<std::string>& param_var,
-                       const std::vector<NumberAssertionType>& assertions);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, std::vector<double>& param_var,
-                       const std::vector<NumberAssertionType>& assertions);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, std::vector<float>& param_var,
-                       const std::vector<NumberAssertionType>& assertions);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, std::vector<int>& param_var,
-                       const std::vector<NumberAssertionType>& assertions);
-template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, std::vector<bool>& param_var,
-                       const std::vector<NumberAssertionType>& assertions);
+#define __DEFINE_TEMPLATES_NOASSERT(T) \
+  template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param_var); \
+  template bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_val, const T& default_val); \
+  template T param(const ros::NodeHandle& nh, const std::string& param_name, const T& default_val);
 
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, std::string& param_var,
-                    const std::string& default_val);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, double& param_var,
-                    const double& default_val);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, float& param_var,
-                    const float& default_val);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, int& param_var, const int& default_val);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, bool& param_var, const bool& default_val);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, std::vector<std::string>& param_var,
-                    const std::vector<std::string>& default_val);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, std::vector<double>& param_var,
-                    const std::vector<double>& default_val);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, std::vector<float>& param_var,
-                    const std::vector<float>& default_val);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, std::vector<int>& param_var,
-                    const std::vector<int>& default_val);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, std::vector<bool>& param_var,
-                    const std::vector<bool>& default_val);
+#define __DEFINE_TEMPLATES_ASSERT(T, A) \
+  template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param_var, \
+                         const std::vector<A>& assertions); \
+  template bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_val, const T& default_val, \
+                      const std::vector<A>& assertions); \
+  template T param(const ros::NodeHandle& nh, const std::string& param_name, const T& default_val, \
+                   const std::vector<A>& assertions);
 
-template std::string param(const ros::NodeHandle& nh, const std::string& param_name, const std::string& default_val);
-template double param(const ros::NodeHandle& nh, const std::string& param_name, const double& default_val);
-template float param(const ros::NodeHandle& nh, const std::string& param_name, const float& default_val);
-template int param(const ros::NodeHandle& nh, const std::string& param_name, const int& default_val);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, const bool& default_val);
-template std::vector<std::string> param(const ros::NodeHandle& nh, const std::string& param_name,
-                                        const std::vector<std::string>& default_val);
-template std::vector<double> param(const ros::NodeHandle& nh, const std::string& param_name,
-                                   const std::vector<double>& default_val);
-template std::vector<float> param(const ros::NodeHandle& nh, const std::string& param_name,
-                                  const std::vector<float>& default_val);
-template std::vector<int> param(const ros::NodeHandle& nh, const std::string& param_name,
-                                const std::vector<int>& default_val);
-template std::vector<bool> param(const ros::NodeHandle& nh, const std::string& param_name,
-                                 const std::vector<bool>& default_val);
+#define SINGLE_ARG(...) __VA_ARGS__
 
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, std::string& param_var,
-                    const std::string& default_val, const std::vector<NumberAssertionType>& assertions);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, double& param_var,
-                    const double& default_val, const std::vector<NumberAssertionType>& assertions);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, float& param_var,
-                    const float& default_val, const std::vector<NumberAssertionType>& assertions);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, int& param_var, const int& default_val,
-                    const std::vector<NumberAssertionType>& assertions);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, bool& param_var, const bool& default_val,
-                    const std::vector<NumberAssertionType>& assertions);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, std::vector<std::string>& param_var,
-                    const std::vector<std::string>& default_val, const std::vector<NumberAssertionType>& assertions);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, std::vector<double>& param_var,
-                    const std::vector<double>& default_val, const std::vector<NumberAssertionType>& assertions);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, std::vector<float>& param_var,
-                    const std::vector<float>& default_val, const std::vector<NumberAssertionType>& assertions);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, std::vector<int>& param_var,
-                    const std::vector<int>& default_val, const std::vector<NumberAssertionType>& assertions);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, std::vector<bool>& param_var,
-                    const std::vector<bool>& default_val, const std::vector<NumberAssertionType>& assertions);
+#define __DEFINE_TEMPLATES_NONNUMERIC(T) \
+  __DEFINE_TEMPLATES_NOASSERT(SINGLE_ARG(T)) \
+  __DEFINE_TEMPLATES_ASSERT(SINGLE_ARG(T), Assertion<SINGLE_ARG(T)>)
 
-template std::string param(const ros::NodeHandle& nh, const std::string& param_name, const std::string& default_val,
-                           const std::vector<NumberAssertionType>& assertions);
-template double param(const ros::NodeHandle& nh, const std::string& param_name, const double& default_val,
-                      const std::vector<NumberAssertionType>& assertions);
-template float param(const ros::NodeHandle& nh, const std::string& param_name, const float& default_val,
-                     const std::vector<NumberAssertionType>& assertions);
-template int param(const ros::NodeHandle& nh, const std::string& param_name, const int& default_val,
-                   const std::vector<NumberAssertionType>& assertions);
-template bool param(const ros::NodeHandle& nh, const std::string& param_name, const bool& default_val,
-                    const std::vector<NumberAssertionType>& assertions);
-template std::vector<std::string> param(const ros::NodeHandle& nh, const std::string& param_name,
-                                        const std::vector<std::string>& default_val,
-                                        const std::vector<NumberAssertionType>& assertions);
-template std::vector<double> param(const ros::NodeHandle& nh, const std::string& param_name,
-                                   const std::vector<double>& default_val,
-                                   const std::vector<NumberAssertionType>& assertions);
-template std::vector<float> param(const ros::NodeHandle& nh, const std::string& param_name,
-                                  const std::vector<float>& default_val,
-                                  const std::vector<NumberAssertionType>& assertions);
-template std::vector<int> param(const ros::NodeHandle& nh, const std::string& param_name,
-                                const std::vector<int>& default_val,
-                                const std::vector<NumberAssertionType>& assertions);
-template std::vector<bool> param(const ros::NodeHandle& nh, const std::string& param_name,
-                                 const std::vector<bool>& default_val,
-                                 const std::vector<NumberAssertionType>& assertions);
+#define __DEFINE_TEMPLATES_NUMERIC(T) \
+  __DEFINE_TEMPLATES_NONNUMERIC(SINGLE_ARG(T)) \
+  __DEFINE_TEMPLATES_ASSERT(SINGLE_ARG(T), NumberAssertionType)
+
+__DEFINE_TEMPLATES_NONNUMERIC(std::string)
+__DEFINE_TEMPLATES_NONNUMERIC(std::vector<std::string>)
+__DEFINE_TEMPLATES_NONNUMERIC(SINGLE_ARG(std::map<std::string, std::string>))
+
+__DEFINE_TEMPLATES_NONNUMERIC(bool)
+__DEFINE_TEMPLATES_NONNUMERIC(std::vector<bool>)
+__DEFINE_TEMPLATES_NONNUMERIC(SINGLE_ARG(std::map<std::string, bool>))
+
+__DEFINE_TEMPLATES_NUMERIC(double)
+__DEFINE_TEMPLATES_NUMERIC(std::vector<double>)
+__DEFINE_TEMPLATES_NUMERIC(SINGLE_ARG(std::map<std::string, double>))
+
+__DEFINE_TEMPLATES_NUMERIC(float)
+__DEFINE_TEMPLATES_NUMERIC(std::vector<float>)
+__DEFINE_TEMPLATES_NUMERIC(SINGLE_ARG(std::map<std::string, float>))
+
+__DEFINE_TEMPLATES_NUMERIC(int)
+__DEFINE_TEMPLATES_NUMERIC(std::vector<int>)
+__DEFINE_TEMPLATES_NUMERIC(SINGLE_ARG(std::map<std::string, int>))
+
+__DEFINE_TEMPLATES_NONNUMERIC(XmlRpc::XmlRpcValue)
+
 }  // namespace assertions

--- a/parameter_assertions/src/assertions.cpp
+++ b/parameter_assertions/src/assertions.cpp
@@ -165,7 +165,8 @@ bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_va
     }
     else
     {
-      ROS_WARN_STREAM("[" << nh.getNamespace() << "] " << *message << ". Continuing with default parameter.");
+      ROS_WARN_STREAM("[" << nh.getNamespace() << "] " << param_name << " expects " << *message
+          << ". Continuing with default parameter.");
     }
   }
 
@@ -175,7 +176,7 @@ bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_va
   {
     return false;
   }
-  ROS_ERROR_STREAM("[" << nh.getNamespace() << "] " << *message << ". Exiting...");
+  ROS_ERROR_STREAM("[" << nh.getNamespace() << "] " << param_name << " expects " << *message << ". Exiting...");
   fail();
 
   return false;
@@ -242,7 +243,8 @@ bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param
   {
     if (auto message = getErrorMessage(param_var, assertions))
     {
-      ROS_ERROR_STREAM("[" << nh.getNamespace() << "] " << *message << ". Exiting...");
+      ROS_ERROR_STREAM("[" << nh.getNamespace() << "] " << param_name << " expects " << *message
+          << ". Exiting...");
       fail();
       return false;
     }

--- a/parameter_assertions/src/assertions.cpp
+++ b/parameter_assertions/src/assertions.cpp
@@ -166,7 +166,7 @@ bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_va
     else
     {
       ROS_WARN_STREAM("[" << nh.getNamespace() << "] " << param_name << " expects " << *message
-          << ". Continuing with default parameter.");
+                          << ". Continuing with default parameter.");
     }
   }
 
@@ -243,8 +243,7 @@ bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param
   {
     if (auto message = getErrorMessage(param_var, assertions))
     {
-      ROS_ERROR_STREAM("[" << nh.getNamespace() << "] " << param_name << " expects " << *message
-          << ". Exiting...");
+      ROS_ERROR_STREAM("[" << nh.getNamespace() << "] " << param_name << " expects " << *message << ". Exiting...");
       fail();
       return false;
     }

--- a/parameter_assertions/src/assertions.cpp
+++ b/parameter_assertions/src/assertions.cpp
@@ -65,28 +65,28 @@ Assertion<T> getNumericAssertion(NumberAssertionType assertion_type, const T& va
   switch (assertion_type)
   {
     case NumberAssertionType::POSITIVE:
-      return {[](const T& param) { return param > 0; }, std::to_string(variable) + " must be > 0."};
+      return { [](const T& param) { return param > 0; }, std::to_string(variable) + " must be > 0." };
     case NumberAssertionType::NON_NEGATIVE:
-      return {[](const T& param) { return param >= 0; }, std::to_string(variable) + " must be >= 0."};
+      return { [](const T& param) { return param >= 0; }, std::to_string(variable) + " must be >= 0." };
     case NumberAssertionType::NEGATIVE:
-      return {[](const T& param) { return param < 0; }, std::to_string(variable) + " must be < 0."};
+      return { [](const T& param) { return param < 0; }, std::to_string(variable) + " must be < 0." };
     case NumberAssertionType::NON_POSITIVE:
-      return {[](const T& param) { return param <= 0; }, std::to_string(variable) + " must be <= 0."};
+      return { [](const T& param) { return param <= 0; }, std::to_string(variable) + " must be <= 0." };
     case NumberAssertionType::LESS_THAN_EQ_ONE:
-      return {[](const T& param) { return param <= 1; }, std::to_string(variable) + " must be <= 1."};
+      return { [](const T& param) { return param <= 1; }, std::to_string(variable) + " must be <= 1." };
     case NumberAssertionType::ABS_LESS_THAN_EQ_ONE:
-      return {[](const T& param) { return std::abs(param) <= 1; },
-              std::to_string(variable) + " must have an absolute value <= 1."};
+      return { [](const T& param) { return std::abs(param) <= 1; },
+               std::to_string(variable) + " must have an absolute value <= 1." };
     default:
       ROS_ERROR_STREAM("default case reached in getNumericAssertion even though match was exhaustive");
-      return {[](const T& /*param*/) { return false; }, "valid NumberAssertionType"};
+      return { [](const T& /*param*/) { return false; }, "valid NumberAssertionType" };
   }
 }
 
 template <typename T>
 std::optional<std::string> getErrorMessage(const T& variable, const std::vector<Assertion<T>>& assertions)
 {
-  for (const Assertion<T>& assertion: assertions)
+  for (const Assertion<T>& assertion : assertions)
   {
     if (!assertion.predicate(variable))
     {
@@ -103,26 +103,35 @@ void fail()
 
 }  // namespace
 
-template <typename T> Assertion<T> greater(const T& rhs) {
+template <typename T>
+Assertion<T> greater(const T& rhs)
+{
   return Assertion<T>([&rhs](const T& lhs) { return lhs > rhs; }, "x > " + std::to_string(rhs));
 }
 
-template <typename T> Assertion<T> greater_eq(const T& rhs) {
+template <typename T>
+Assertion<T> greater_eq(const T& rhs)
+{
   return Assertion<T>([&rhs](const T& lhs) { return lhs >= rhs; }, "x >= " + std::to_string(rhs));
 }
 
-template <typename T> Assertion<T> less(const T& rhs) {
+template <typename T>
+Assertion<T> less(const T& rhs)
+{
   return Assertion<T>([&rhs](const T& lhs) { return lhs < rhs; }, "x < " + std::to_string(rhs));
 }
 
-template <typename T> Assertion<T> less_eq(const T& rhs) {
+template <typename T>
+Assertion<T> less_eq(const T& rhs)
+{
   return Assertion<T>([&rhs](const T& lhs) { return lhs <= rhs; }, "x <= " + std::to_string(rhs));
 }
 
-template <typename T> Assertion<T> size(size_t n) {
+template <typename T>
+Assertion<T> size(size_t n)
+{
   return Assertion<T>([n](const T& c) { return c.size() == n; }, "container.size() = " + std::to_string(n));
 }
-
 
 template <typename T>
 bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_var, const T& default_val)
@@ -177,7 +186,8 @@ bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_va
            const std::vector<NumberAssertionType>& numeric_assertions)
 {
   std::vector<Assertion<T>> assertions;
-  for (auto numeric_assertion : numeric_assertions) {
+  for (auto numeric_assertion : numeric_assertions)
+  {
     assertions.push_back(getNumericAssertion(numeric_assertion, param_var));
   }
   return param(nh, param_name, param_var, default_val, assertions);
@@ -246,7 +256,8 @@ bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param
               const std::vector<NumberAssertionType>& numeric_assertions)
 {
   std::vector<Assertion<T>> assertions;
-  for (auto numeric_assertion : numeric_assertions) {
+  for (auto numeric_assertion : numeric_assertions)
+  {
     assertions.push_back(getNumericAssertion(numeric_assertion, param_var));
   }
   return getParam(nh, param_name, param_var, assertions);
@@ -262,38 +273,37 @@ bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param
   return getParam(nh, param_name, param_var);
 }
 
-
 // *********************** generate templated code *************************** //
 
-#define __DEFINE_TEMPLATES_NOASSERT(T) \
-  template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param_var); \
-  template bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_val, const T& default_val); \
+#define __DEFINE_TEMPLATES_NOASSERT(T)                                                                                 \
+  template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param_var);                      \
+  template bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_val, const T& default_val);   \
   template T param(const ros::NodeHandle& nh, const std::string& param_name, const T& default_val);
 
-#define __DEFINE_TEMPLATES_ASSERT(T, A) \
-  template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param_var, \
-                         const std::vector<A>& assertions); \
-  template bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_val, const T& default_val, \
-                      const std::vector<A>& assertions); \
-  template T param(const ros::NodeHandle& nh, const std::string& param_name, const T& default_val, \
+#define __DEFINE_TEMPLATES_ASSERT(T, A)                                                                                \
+  template bool getParam(const ros::NodeHandle& nh, const std::string& param_name, T& param_var,                       \
+                         const std::vector<A>& assertions);                                                            \
+  template bool param(const ros::NodeHandle& nh, const std::string& param_name, T& param_val, const T& default_val,    \
+                      const std::vector<A>& assertions);                                                               \
+  template T param(const ros::NodeHandle& nh, const std::string& param_name, const T& default_val,                     \
                    const std::vector<A>& assertions);
 
 #define SINGLE_ARG(...) __VA_ARGS__
 
-#define __DEFINE_TEMPLATES_GENERAL(T) \
-  __DEFINE_TEMPLATES_NOASSERT(SINGLE_ARG(T)) \
+#define __DEFINE_TEMPLATES_GENERAL(T)                                                                                  \
+  __DEFINE_TEMPLATES_NOASSERT(SINGLE_ARG(T))                                                                           \
   __DEFINE_TEMPLATES_ASSERT(SINGLE_ARG(T), Assertion<SINGLE_ARG(T)>)
 
-#define __DEFINE_TEMPLATES_NUMERIC(T) \
-  __DEFINE_TEMPLATES_GENERAL(SINGLE_ARG(T)) \
-  __DEFINE_TEMPLATES_ASSERT(SINGLE_ARG(T), NumberAssertionType) \
-  template Assertion<T> greater(const T& rhs); \
-  template Assertion<T> greater_eq(const T& rhs); \
-  template Assertion<T> less(const T& rhs); \
+#define __DEFINE_TEMPLATES_NUMERIC(T)                                                                                  \
+  __DEFINE_TEMPLATES_GENERAL(SINGLE_ARG(T))                                                                            \
+  __DEFINE_TEMPLATES_ASSERT(SINGLE_ARG(T), NumberAssertionType)                                                        \
+  template Assertion<T> greater(const T& rhs);                                                                         \
+  template Assertion<T> greater_eq(const T& rhs);                                                                      \
+  template Assertion<T> less(const T& rhs);                                                                            \
   template Assertion<T> less_eq(const T& rhs);
 
-#define __DEFINE_TEMPLATES_CONTAINER(T) \
-  __DEFINE_TEMPLATES_GENERAL(SINGLE_ARG(T)) \
+#define __DEFINE_TEMPLATES_CONTAINER(T)                                                                                \
+  __DEFINE_TEMPLATES_GENERAL(SINGLE_ARG(T))                                                                            \
   template Assertion<T> size(size_t n);
 
 __DEFINE_TEMPLATES_CONTAINER(std::string)

--- a/parameter_assertions/test/CMakeLists.txt
+++ b/parameter_assertions/test/CMakeLists.txt
@@ -11,3 +11,6 @@ target_link_libraries(test_getParam_with_assertions ${PARAMETER_ASSERTIONS_TEST_
 
 add_rostest_gtest(test_param_with_assertions test_param_with_assertions.test test_param_with_assertions.cpp)
 target_link_libraries(test_param_with_assertions ${PARAMETER_ASSERTIONS_TEST_LIBRARIES})
+
+add_rostest_gtest(test_complex_datatypes test_complex_datatypes.test test_complex_datatypes.cpp)
+target_link_libraries(test_complex_datatypes ${PARAMETER_ASSERTIONS_TEST_LIBRARIES})

--- a/parameter_assertions/test/test_complex_datatypes.cpp
+++ b/parameter_assertions/test/test_complex_datatypes.cpp
@@ -8,10 +8,9 @@ class TestAssertions : public testing::Test
 {
 public:
   TestAssertions()
-    : handle_("~"),
-      list_true({10, 11, 12, 13}),
-      dict_true({{"foo", "forty-two"}, {"bar", "hello, world"}})
-  {}
+    : handle_("~"), list_true({ 10, 11, 12, 13 }), dict_true({ { "foo", "forty-two" }, { "bar", "hello, world" } })
+  {
+  }
 
 protected:
   void SetUp() override
@@ -19,19 +18,24 @@ protected:
     ros::start();
   }
 
-  void TearDown() override {
-    if (ros::ok()) {
+  void TearDown() override
+  {
+    if (ros::ok())
+    {
       ros::shutdown();
     }
   }
 
-  void CheckDict(std::map<std::string, std::string> v) {
-    for (const auto& true_pair : dict_true) {
+  void CheckDict(std::map<std::string, std::string> v)
+  {
+    for (const auto& true_pair : dict_true)
+    {
       EXPECT_STREQ(v[true_pair.first].c_str(), true_pair.second.c_str());
     }
   }
 
-  void CheckCoordsList(XmlRpc::XmlRpcValue v) {
+  void CheckCoordsList(XmlRpc::XmlRpcValue v)
+  {
     EXPECT_EQ(v.getType(), XmlRpc::XmlRpcValue::TypeArray);
     EXPECT_DOUBLE_EQ(v[0]["x"], 1);
     EXPECT_DOUBLE_EQ(v[0]["y"], 2);
@@ -48,10 +52,10 @@ protected:
 
 TEST_F(TestAssertions, getParamList)
 {
-    std::vector<int> v;
-    EXPECT_TRUE(assertions::getParam(handle_, "list", v));
-    EXPECT_FLOAT_VEC_EQ(v, list_true);
-    EXPECT_ROS_ALIVE();
+  std::vector<int> v;
+  EXPECT_TRUE(assertions::getParam(handle_, "list", v));
+  EXPECT_FLOAT_VEC_EQ(v, list_true);
+  EXPECT_ROS_ALIVE();
 }
 
 TEST_F(TestAssertions, paramList)
@@ -150,48 +154,43 @@ TEST_F(TestAssertions, getParamListAssertLengthFail)
   EXPECT_ROS_DEAD();
 }
 
-TEST_F(TestAssertions, paramXmlRpcAssertion) {
+TEST_F(TestAssertions, paramXmlRpcAssertion)
+{
   XmlRpc::XmlRpcValue v;
-  assertions::param(handle_, "coords_list", v, v, {
-      { [](XmlRpc::XmlRpcValue v) { return v.getType() == v.TypeArray && v.size() == 2; },
-        "XmlRpcValue is array of length 2" }
-  });
+  auto check_array_length_2 = [](const XmlRpc::XmlRpcValue& v) { return v.getType() == v.TypeArray && v.size() == 2; };
+  assertions::param(handle_, "coords_list", v, v, { { check_array_length_2, "XmlRpcValue is array of length 2" } });
   CheckCoordsList(v);
   EXPECT_ROS_ALIVE();
 }
 
-TEST_F(TestAssertions, paramDoubleInRange1) {
-  double x = assertions::param(handle_, "double", 0.0, {
-    assertions::greater(3.0), assertions::less(10.0)
-  });
+TEST_F(TestAssertions, paramDoubleInRange1)
+{
+  double x = assertions::param(handle_, "double", 0.0, { assertions::greater(3.0), assertions::less(10.0) });
   EXPECT_DOUBLE_EQ(x, 5.0);
   EXPECT_ROS_ALIVE();
 }
 
-TEST_F(TestAssertions, paramDoubleInRange2) {
+TEST_F(TestAssertions, paramDoubleInRange2)
+{
   double x = -100.0;
-  bool success = assertions::param(handle_, "double", x, 0.0, {
-      assertions::greater(-1.0), assertions::less(1.0)
-  });
+  bool success = assertions::param(handle_, "double", x, 0.0, { assertions::greater(-1.0), assertions::less(1.0) });
   EXPECT_FALSE(success);
   EXPECT_DOUBLE_EQ(x, 0.0);
   EXPECT_ROS_ALIVE();
 }
 
-TEST_F(TestAssertions, paramDoubleInRange3) {
+TEST_F(TestAssertions, paramDoubleInRange3)
+{
   double x = -100.0;
-  bool success = assertions::param(handle_, "double", x, 0.0, {
-      assertions::greater(-10.0), assertions::less(-5.0)
-  });
+  bool success = assertions::param(handle_, "double", x, 0.0, { assertions::greater(-10.0), assertions::less(-5.0) });
   EXPECT_FALSE(success);
   EXPECT_ROS_DEAD();
 }
 
-TEST_F(TestAssertions, paramMapFallback) {
+TEST_F(TestAssertions, paramMapFallback)
+{
   std::map<std::string, std::string> dict;
-  dict = assertions::param(handle_, "list", dict, {
-    assertions::size<std::map<std::string, std::string>>(0)
-  });
+  dict = assertions::param(handle_, "list", dict, { assertions::size<std::map<std::string, std::string>>(0) });
   EXPECT_EQ(dict.size(), 0);
   EXPECT_ROS_ALIVE();
 }

--- a/parameter_assertions/test/test_complex_datatypes.cpp
+++ b/parameter_assertions/test/test_complex_datatypes.cpp
@@ -1,0 +1,204 @@
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+
+#include <parameter_assertions/assertions.h>
+#include "macro_lib.h"
+
+class TestAssertions : public testing::Test
+{
+public:
+  TestAssertions()
+    : handle_("~"),
+      list_true({10, 11, 12, 13}),
+      dict_true({{"foo", "forty-two"}, {"bar", "hello, world"}})
+  {}
+
+protected:
+  void SetUp() override
+  {
+    ros::start();
+  }
+
+  void TearDown() override {
+    if (ros::ok()) {
+      ros::shutdown();
+    }
+  }
+
+  void CheckDict(std::map<std::string, std::string> v) {
+    for (const auto& true_pair : dict_true) {
+      EXPECT_STREQ(v[true_pair.first].c_str(), true_pair.second.c_str());
+    }
+  }
+
+  void CheckCoordsList(XmlRpc::XmlRpcValue v) {
+    EXPECT_EQ(v.getType(), XmlRpc::XmlRpcValue::TypeArray);
+    EXPECT_DOUBLE_EQ(v[0]["x"], 1);
+    EXPECT_DOUBLE_EQ(v[0]["y"], 2);
+    EXPECT_DOUBLE_EQ(v[0]["z"], 3);
+    EXPECT_DOUBLE_EQ(v[1]["x"], 10);
+    EXPECT_DOUBLE_EQ(v[1]["y"], 11);
+    EXPECT_DOUBLE_EQ(v[1]["z"], 12);
+  }
+
+  ros::NodeHandle handle_;
+  std::vector<double> list_true;
+  std::map<std::string, std::string> dict_true;
+};
+
+TEST_F(TestAssertions, getParamList)
+{
+    std::vector<int> v;
+    EXPECT_TRUE(assertions::getParam(handle_, "list", v));
+    EXPECT_FLOAT_VEC_EQ(v, list_true);
+    EXPECT_ROS_ALIVE();
+}
+
+TEST_F(TestAssertions, paramList)
+{
+  std::vector<int> v;
+  EXPECT_TRUE(assertions::param(handle_, "list", v, v));
+  EXPECT_FLOAT_VEC_EQ(v, list_true);
+  EXPECT_ROS_ALIVE();
+}
+
+TEST_F(TestAssertions, param2List)
+{
+  std::vector<int> v;
+  v = assertions::param(handle_, "list", v);
+  EXPECT_FLOAT_VEC_EQ(v, list_true);
+  EXPECT_ROS_ALIVE();
+}
+
+TEST_F(TestAssertions, getParamDict)
+{
+  std::map<std::string, std::string> dict;
+  assertions::getParam(handle_, "dict", dict);
+  CheckDict(dict);
+  EXPECT_ROS_ALIVE();
+}
+
+TEST_F(TestAssertions, paramDict)
+{
+  std::map<std::string, std::string> dict;
+  assertions::param(handle_, "dict", dict, dict);
+  CheckDict(dict);
+  EXPECT_ROS_ALIVE();
+}
+
+TEST_F(TestAssertions, param2Dict)
+{
+  std::map<std::string, std::string> dict;
+  dict = assertions::param(handle_, "dict", dict);
+  CheckDict(dict);
+  EXPECT_ROS_ALIVE();
+}
+
+TEST_F(TestAssertions, getParamCoordsList)
+{
+  XmlRpc::XmlRpcValue v;
+  assertions::getParam(handle_, "coords_list", v);
+  CheckCoordsList(v);
+  EXPECT_ROS_ALIVE();
+}
+
+TEST_F(TestAssertions, paramCoordsList)
+{
+  XmlRpc::XmlRpcValue v;
+  assertions::param(handle_, "coords_list", v, v);
+  CheckCoordsList(v);
+  EXPECT_ROS_ALIVE();
+}
+
+TEST_F(TestAssertions, param2CoordsList)
+{
+  XmlRpc::XmlRpcValue v;
+  v = assertions::param(handle_, "coords_list", v);
+  CheckCoordsList(v);
+  EXPECT_ROS_ALIVE();
+}
+
+TEST_F(TestAssertions, getParamListMissing)
+{
+  std::vector<int> v;
+  EXPECT_FALSE(assertions::getParam(handle_, "wrong_name", v));
+  EXPECT_TRUE(v.empty());
+  EXPECT_ROS_DEAD();
+}
+
+TEST_F(TestAssertions, paramListMissing)
+{
+  std::vector<int> v;
+  EXPECT_FALSE(assertions::param(handle_, "wrong_name", v, v));
+  EXPECT_TRUE(v.empty());
+  EXPECT_ROS_ALIVE();
+}
+
+TEST_F(TestAssertions, param2ListMissing)
+{
+  std::vector<int> v;
+  v = assertions::param(handle_, "wrong_name", v);
+  EXPECT_TRUE(v.empty());
+  EXPECT_ROS_ALIVE();
+}
+
+TEST_F(TestAssertions, getParamListAssertLengthFail)
+{
+  std::vector<int> v;
+  bool found = assertions::getParam(handle_, "list", v, { assertions::size<std::vector<int>>(1) });
+  EXPECT_FALSE(found);
+  EXPECT_ROS_DEAD();
+}
+
+TEST_F(TestAssertions, paramXmlRpcAssertion) {
+  XmlRpc::XmlRpcValue v;
+  assertions::param(handle_, "coords_list", v, v, {
+      { [](XmlRpc::XmlRpcValue v) { return v.getType() == v.TypeArray && v.size() == 2; },
+        "XmlRpcValue is array of length 2" }
+  });
+  CheckCoordsList(v);
+  EXPECT_ROS_ALIVE();
+}
+
+TEST_F(TestAssertions, paramDoubleInRange1) {
+  double x = assertions::param(handle_, "double", 0.0, {
+    assertions::greater(3.0), assertions::less(10.0)
+  });
+  EXPECT_DOUBLE_EQ(x, 5.0);
+  EXPECT_ROS_ALIVE();
+}
+
+TEST_F(TestAssertions, paramDoubleInRange2) {
+  double x = -100.0;
+  bool success = assertions::param(handle_, "double", x, 0.0, {
+      assertions::greater(-1.0), assertions::less(1.0)
+  });
+  EXPECT_FALSE(success);
+  EXPECT_DOUBLE_EQ(x, 0.0);
+  EXPECT_ROS_ALIVE();
+}
+
+TEST_F(TestAssertions, paramDoubleInRange3) {
+  double x = -100.0;
+  bool success = assertions::param(handle_, "double", x, 0.0, {
+      assertions::greater(-10.0), assertions::less(-5.0)
+  });
+  EXPECT_FALSE(success);
+  EXPECT_ROS_DEAD();
+}
+
+TEST_F(TestAssertions, paramMapFallback) {
+  std::map<std::string, std::string> dict;
+  dict = assertions::param(handle_, "list", dict, {
+    assertions::size<std::map<std::string, std::string>>(0)
+  });
+  EXPECT_EQ(dict.size(), 0);
+  EXPECT_ROS_ALIVE();
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "test_complex_datatypes");
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/parameter_assertions/test/test_complex_datatypes.test
+++ b/parameter_assertions/test/test_complex_datatypes.test
@@ -1,0 +1,14 @@
+<launch>
+  <test test-name="test_complex_datatypes" pkg="parameter_assertions" type="test_complex_datatypes">
+    <rosparam>
+      double: 5.0
+      list: [10, 11, 12, 13]
+      dict:
+        foo: "forty-two"
+        bar: "hello, world"
+      coords_list:
+        - {x: 1.0, y: 2.0, z: 3.0}
+        - {x: 10.0, y: 11.0, z: 12.0}
+    </rosparam>
+  </test>
+</launch>


### PR DESCRIPTION
Fixes #1 
- Adds a new class of Assertions which can be specified at runtime to perform arbitrary checks on parameters
- Adds functions greater, less, greater_eq, less_eq which generate Assertions for numeric types
- Condenses some of the repetitious listing of each library function for each supported type
- Adds tests for new functionality